### PR TITLE
deploy Azure SQL Data Warehouse Gen2

### DIFF
--- a/Deployment/LabARM.json
+++ b/Deployment/LabARM.json
@@ -136,12 +136,16 @@
         {
           "type": "databases",
           "name": "AirlinePerformance-DW",
-          "apiVersion": "2014-04-01-preview",
+          "apiVersion": "2023-05-01-preview",
           "location": "[resourceGroup().location]",
+          "sku": {
+            "name": "DataWarehouse",
+            "tier": "DataWarehouse",
+            "capacity": 900
+          },
+          "kind": "v12.0,user,datawarehouse,gen2",
           "properties": {
-            "edition": "DataWarehouse",
             "collation": "SQL_Latin1_General_CP1_CI_AS",
-            "requestedServiceObjectiveName": "DW100"
           },
           "dependsOn": [
             "[variables('sqlServerName')]"


### PR DESCRIPTION
Still valuable materials after all these years! Change allows to successfully deploy Azure SQL Data Warehouse Gen2. Related to issue #31, #29, #27.